### PR TITLE
Add CI pipelines and make

### DIFF
--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.8'
+
+    - name: Run Makefile
+      run: make -B

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+name: Release to PyPI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.8'
+
+    - name: Build the package
+      run: make build
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: objs/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/**
 .idea/
 test_run_logs/
 
+objs
 dist
 build
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+ARTIFACTS_DIR := objs
+ENV_DIR := $(ARTIFACTS_DIR)/.env
+DIST_DIR := $(ARTIFACTS_DIR)/dist
+VERSION := $(shell grep -Po '(?<=^version = ")[^"]*' pyproject.toml)
+DIST_WHL := $(DIST_DIR)/coppercomm-$(VERSION)-py3-none-any.whl
+
+.PHONY: all test build clean requirements
+
+all: test build
+
+test: requirements
+	hatch run test
+
+build: requirements $(DIST_WHL)
+
+$(DIST_WHL):
+	rm -rf $(DIST_DIR)
+	hatch build
+
+requirements: $(ENV_DIR)
+
+$(ENV_DIR):
+	pip install hatch pytest
+	hatch env create
+
+clean:
+	rm -rf $(ARTIFACTS_DIR)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Coppercomm
 
 Coppercomm is a lightweight library, written in Python. It is used by tests for communicating through different protocols.
 
-![Coppercomm overview](images/coppercomm_overview.png)
+![Coppercomm overview](https://raw.githubusercontent.com/volvo-cars/coppercomm/cf0f53986e5d438f1c485191af390252ece99e19/images/coppercomm_overview.png)
 
 Introduction
 ------------
@@ -12,10 +12,10 @@ One challenge with sharing test cases across different organizations/companies i
 
 When test cases across companies and organizations are using Coppercomm, the test cases can be executed without modifications or if-statements for different environments, in the test cases. It becomes convenient to execute test cases at different places.
 
-![Coppercomm overview](images/coppercomm_config.png)
+![Coppercomm overview](https://raw.githubusercontent.com/volvo-cars/coppercomm/cf0f53986e5d438f1c485191af390252ece99e19/images/coppercomm_config.png)
 
 Examples
 --------
 There are some examples on how to use it here:
-[test_example_pytest.py](examples/test_example_pytest.py).
+[test_example_pytest.py](https://raw.githubusercontent.com/volvo-cars/coppercomm/cf0f53986e5d438f1c485191af390252ece99e19/examples/test_example_pytest.py).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,24 +6,32 @@ build-backend = "hatchling.build"
 name = "coppercomm"
 version = "0.1.0"
 description = "Coppercomm"
+readme = "README.md"
 authors = [{ name = "Volvo Cars" }]
 license = { file = "LICENSE" }
+requires-python = ">=3.8"
 
 dependencies = ["paramiko", "pyserial", "pexpect"]
 
+[project.urls]
+Homepage = "https://github.com/volvo-cars/coppercomm"
+Issues = "https://github.com/volvo-cars/coppercomm/issues"
+
 [tool.hatch.envs.default]
 dependencies = ["types-paramiko", "mypy >= 0.991"]
+path = "objs/.env"
+
+[tool.hatch.build]
+directory = "objs/dist"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/coppercomm"]
 
-[tool.hatch.build.targets.sdist]
-include = ["src/coppercomm"]
 
 [tool.hatch.envs.default.scripts]
-test = "pytest {args:tests}"
-system-test = "pytest ./system_tests"
-test-cov = "coverage run -m pytest {args:tests}"
+test = "pytest -o cache_dir=objs/.pytest_cache {args:tests}"
+system-test = "pytest -o cache_dir=objs/.pytest_cache ./system_tests"
+test-cov = "coverage run -m pytest -o cache_dir=objs/.pytest_cache {args:tests}"
 cov-report = ["- coverage combine", "coverage report"]
 cov = ["test-cov", "cov-report"]
 


### PR DESCRIPTION
Introduced CI pipelines and a dispatch for manual releasing. Also using make here to build and whatnot, although does not affect previous workflow other than dumping all environments and artifacts in the objs/ directory instead of repo root.